### PR TITLE
Fixes permissions problem when using boot2docker + OSX mirror mounts …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,6 @@
 FROM php:5.6-apache
+
+RUN usermod -u 1000 www-data; groupmod -g 1000 www-data; chown www-data:www-data /var/www/html/
+
 COPY . /var/www/html/
+


### PR DESCRIPTION
…for user volumes (apache needs to be able to write to the document base.
